### PR TITLE
fix: Update alpine packages to fix security vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.23@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
 
-RUN apk add --no-cache ca-certificates curl bash tar git
+RUN apk add --no-cache ca-certificates curl bash tar git && apk upgrade --no-cache zlib libexpat
 
 COPY src/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh


### PR DESCRIPTION
# Description

This PR fixes:
- CVE-2026-22184 (CRITICAL): zlib buffer overflow vulnerability
- CVE-2026-25210 (HIGH): libexpat integer overflow vulnerability
- CVE-2026-27171 (MEDIUM): zlib denial of service vulnerability
- CVE-2026-24515 (LOW): libexpat null pointer dereference