### PR TITLE
feat: added banner and update subscription check to make maintained actions free for public repos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.23@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
 
-RUN apk add --no-cache ca-certificates curl bash tar git
+RUN apk add --no-cache ca-certificates curl bash tar git jq
 
 COPY src/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![StepSecurity Maintained Action](https://raw.githubusercontent.com/step-security/maintained-actions-assets/main/assets/maintained-action-banner.png)](https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions)
+
 # Helm Publisher
 
 A GitHub Action for publishing Helm charts with Github Pages.

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -107,22 +107,44 @@ main() {
 }
 
 validateSubscription() {
-  API_URL="https://agent.api.stepsecurity.io/v1/github/$GITHUB_REPOSITORY/actions/subscription"
+  REPO_PRIVATE=$(jq -r '.repository.private | tostring' "$GITHUB_EVENT_PATH" 2>/dev/null || echo "")
+  UPSTREAM="stefanprodan/helm-gh-pages"
+  ACTION_REPO="${GITHUB_ACTION_REPOSITORY:-}"
+  DOCS_URL="https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions"
 
-  # Set a timeout for the curl command (3 seconds)
-  RESPONSE=$(curl --max-time 3 -s -w "%{http_code}" "$API_URL" -o /dev/null) || true
-  CURL_EXIT_CODE=${?}
-  
-  # Decide based on curl exit code and HTTP status
-  if [ $CURL_EXIT_CODE -ne 0 ]; then
-    echo "Timeout or API not reachable. Continuing to next step."
-  elif [ "$RESPONSE" = "200" ]; then
-    :
-  elif [ "$RESPONSE" = "403" ]; then
-    echo "Subscription is not valid. Reach out to support@stepsecurity.io"
-    exit 1
-  else
-    echo "Timeout or API not reachable. Continuing to next step."
+  echo ""
+  echo -e "\033[1;36mStepSecurity Maintained Action\033[0m"
+  echo "Secure drop-in replacement for $UPSTREAM"
+  if [ "$REPO_PRIVATE" = "false" ]; then
+    echo -e "\033[32m✓ Free for public repositories\033[0m"
+  fi
+  echo -e "\033[36mLearn more:\033[0m $DOCS_URL"
+  echo ""
+
+  if [ "$REPO_PRIVATE" != "false" ]; then
+    SERVER_URL="${GITHUB_SERVER_URL:-https://github.com}"
+
+    if [ "$SERVER_URL" != "https://github.com" ]; then
+      BODY=$(printf '{"action":"%s","ghes_server":"%s"}' "$ACTION_REPO" "$SERVER_URL")
+    else
+      BODY=$(printf '{"action":"%s"}' "$ACTION_REPO")
+    fi
+
+    API_URL="https://agent.api.stepsecurity.io/v1/github/$GITHUB_REPOSITORY/actions/maintained-actions-subscription"
+
+    RESPONSE=$(curl --max-time 3 -s -w "%{http_code}" \
+      -X POST \
+      -H "Content-Type: application/json" \
+      -d "$BODY" \
+      "$API_URL" -o /dev/null) && CURL_EXIT_CODE=0 || CURL_EXIT_CODE=$?
+
+    if [ $CURL_EXIT_CODE -ne 0 ]; then
+      echo "Timeout or API not reachable. Continuing to next step."
+    elif [ "$RESPONSE" = "403" ]; then
+      echo -e "::error::\033[1;31mThis action requires a StepSecurity subscription for private repositories.\033[0m"
+      echo -e "::error::\033[31mLearn how to enable a subscription: $DOCS_URL\033[0m"
+      exit 1
+    fi
   fi
 }
 


### PR DESCRIPTION
## Summary

- Added StepSecurity Maintained Action banner to README.md
- Updated subscription validation: public repositories are now free (no API check)
- Upgraded Node.js runtime to node24 (if applicable)
- Updated workflow files with configurable node_version input (if applicable)

## Changes by type
- **TypeScript/JS actions**: replaced `validateSubscription()` body, updated action.yml to node24, updated 3 workflow files, rebuilt dist/
- **Docker actions**: replaced entrypoint.sh subscription block, ensured jq is installed in Dockerfile
- **Composite actions**: added Subscription check step to action.yml

## Verification
- [ ] Subscription check skips for public repos
- [ ] Subscription check fires for private repos
- [ ] README banner is present at the top
- [ ] Build passes (TS/JS actions)

Auto-generated by StepSecurity update-propagator. Task ID: 20260409T050436Z